### PR TITLE
update ILogger interface, and it's no longer compatible with log/syslog....

### DIFF
--- a/ilogger.go
+++ b/ilogger.go
@@ -1,9 +1,28 @@
 package core
 
-// logger interface, log/syslog conform with this interface
+type LogLevel int
+
+const (
+	// !nashtsai! following level also match syslog.Priority value
+	LOG_UNKNOWN LogLevel = iota - 2
+	LOG_OFF     LogLevel = iota - 1
+	LOG_ERR     LogLevel = iota + 3
+	LOG_WARNING
+	LOG_INFO LogLevel = iota + 6
+	LOG_DEBUG
+)
+
+// logger interface
 type ILogger interface {
-	Debug(m string) (err error)
-	Err(m string) (err error)
-	Info(m string) (err error)
-	Warning(m string) (err error)
+	Debug(v ...interface{}) (err error)
+	Debugf(format string, v ...interface{}) (err error)
+	Err(v ...interface{}) (err error)
+	Errf(format string, v ...interface{}) (err error)
+	Info(v ...interface{}) (err error)
+	Infof(format string, v ...interface{}) (err error)
+	Warning(v ...interface{}) (err error)
+	Warningf(format string, v ...interface{}) (err error)
+
+	Level() LogLevel
+	SetLevel(l LogLevel) (err error)
 }


### PR DESCRIPTION
update ILogger interface, and it's no longer compatible with log/syslog.Writer, due to performance design

according tidy-up/logger is also made on xorm repo
