### PR TITLE
Remove memory allocations from Table.GetColumn & Table.GetColumnIdx

### DIFF
--- a/table.go
+++ b/table.go
@@ -47,19 +47,40 @@ func NewTable(name string, t reflect.Type) *Table {
 	}
 }
 
-func (table *Table) GetColumn(name string) *Column {
-	if c, ok := table.columnsMap[strings.ToLower(name)]; ok {
-		return c[0]
+func (table *Table) columnsByName(name string) []*Column {
+
+	n := len(name)
+
+	for k := range table.columnsMap {
+		if len(k) != n {
+			continue
+		}
+		if strings.EqualFold(k, name) {
+			return table.columnsMap[k]
+		}
 	}
 	return nil
 }
 
-func (table *Table) GetColumnIdx(name string, idx int) *Column {
-	if c, ok := table.columnsMap[strings.ToLower(name)]; ok {
-		if idx < len(c) {
-			return c[idx]
-		}
+func (table *Table) GetColumn(name string) *Column {
+
+	cols := table.columnsByName(name)
+
+	if cols != nil {
+		return cols[0]
 	}
+
+	return nil
+}
+
+func (table *Table) GetColumnIdx(name string, idx int) *Column {
+
+	cols := table.columnsByName(name)
+
+	if cols != nil && idx < len(cols) {
+		return cols[idx]
+	}
+
 	return nil
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+var testsGetColumn = []struct {
+	name string
+	idx  int
+}{
+	{"Id", 0},
+	{"Deleted", 0},
+	{"Caption", 0},
+	{"Code_1", 0},
+	{"Code_2", 0},
+	{"Code_3", 0},
+	{"Parent_Id", 0},
+	{"Latitude", 0},
+	{"Longitude", 0},
+}
+
+var table *Table
+
+func init() {
+
+	table = NewEmptyTable()
+
+	var name string
+
+	for i := 0; i < len(testsGetColumn); i++ {
+		// as in Table.AddColumn func
+		name = strings.ToLower(testsGetColumn[i].name)
+
+		table.columnsMap[name] = append(table.columnsMap[name], &Column{})
+	}
+}
+
+func TestGetColumn(t *testing.T) {
+
+	for _, test := range testsGetColumn {
+		if table.GetColumn(test.name) == nil {
+			t.Error("Column not found!")
+		}
+	}
+}
+
+func TestGetColumnIdx(t *testing.T) {
+
+	for _, test := range testsGetColumn {
+		if table.GetColumnIdx(test.name, test.idx) == nil {
+			t.Errorf("Column %s with idx %d not found!", test.name, test.idx)
+		}
+	}
+}
+
+func BenchmarkGetColumnWithToLower(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range testsGetColumn {
+
+			if _, ok := table.columnsMap[strings.ToLower(test.name)]; !ok {
+				b.Errorf("Column not found:%s", test.name)
+			}
+		}
+	}
+}
+
+func BenchmarkGetColumnIdxWithToLower(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range testsGetColumn {
+
+			if c, ok := table.columnsMap[strings.ToLower(test.name)]; ok {
+				if test.idx < len(c) {
+					continue
+				} else {
+					b.Errorf("Bad idx in: %s, %d", test.name, test.idx)
+				}
+			} else {
+				b.Errorf("Column not found: %s, %d", test.name, test.idx)
+			}
+		}
+	}
+}
+
+func BenchmarkGetColumn(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range testsGetColumn {
+			if table.GetColumn(test.name) == nil {
+				b.Errorf("Column not found:%s", test.name)
+			}
+		}
+	}
+}
+
+func BenchmarkGetColumnIdx(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range testsGetColumn {
+			if table.GetColumnIdx(test.name, test.idx) == nil {
+				b.Errorf("Column not found:%s, %d", test.name, test.idx)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This changes removes usage of `strings.ToLower` from `Table.GetColumn` & `Table.GetColumnIdx`. That removes memory allocations to 0 from 2 allocations per column on each call.

Table.GetColumnIdx called twice for each column from xorm `session._row2Bean` (second call in session.getField, which called from _row2Bean). So allocations count = columns_count \* 2 \* 2.

Checked on simple table with 9 fields. Benchmarks from table_test.go (one call per each column):

```
BenchmarkGetColumnWithToLower-4          1000000              2002 ns/op             160 B/op         18 allocs/op                              
BenchmarkGetColumnIdxWithToLower-4       1000000              2052 ns/op             160 B/op         18 allocs/op                              
BenchmarkGetColumn-4                     1000000              1933 ns/op               0 B/op          0 allocs/op                              
BenchmarkGetColumnIdx-4                  1000000              1893 ns/op               0 B/op          0 allocs/op
```
