### PR TITLE
Fix potential data race in Column.fieldPath

### DIFF
--- a/column.go
+++ b/column.go
@@ -32,7 +32,6 @@ type Column struct {
 	IsDeleted       bool
 	IsCascade       bool
 	IsVersion       bool
-	fieldPath       []string
 	DefaultIsEmpty  bool
 	EnumOptions     map[string]int
 	SetOptions      map[string]int
@@ -59,7 +58,6 @@ func NewColumn(name, fieldName string, sqlType SQLType, len1, len2 int, nullable
 		IsDeleted:       false,
 		IsCascade:       false,
 		IsVersion:       false,
-		fieldPath:       nil,
 		DefaultIsEmpty:  false,
 		EnumOptions:     make(map[string]int),
 	}
@@ -121,12 +119,10 @@ func (col *Column) ValueOf(bean interface{}) (*reflect.Value, error) {
 
 func (col *Column) ValueOfV(dataStruct *reflect.Value) (*reflect.Value, error) {
 	var fieldValue reflect.Value
-	if col.fieldPath == nil {
-		col.fieldPath = strings.Split(col.FieldName, ".")
-	}
+	fieldPath := strings.Split(col.FieldName, ".")
 
 	if dataStruct.Type().Kind() == reflect.Map {
-		keyValue := reflect.ValueOf(col.fieldPath[len(col.fieldPath)-1])
+		keyValue := reflect.ValueOf(fieldPath[len(fieldPath)-1])
 		fieldValue = dataStruct.MapIndex(keyValue)
 		return &fieldValue, nil
 	} else if dataStruct.Type().Kind() == reflect.Interface {
@@ -134,19 +130,19 @@ func (col *Column) ValueOfV(dataStruct *reflect.Value) (*reflect.Value, error) {
 		dataStruct = &structValue
 	}
 
-	level := len(col.fieldPath)
-	fieldValue = dataStruct.FieldByName(col.fieldPath[0])
+	level := len(fieldPath)
+	fieldValue = dataStruct.FieldByName(fieldPath[0])
 	for i := 0; i < level-1; i++ {
 		if !fieldValue.IsValid() {
 			break
 		}
 		if fieldValue.Kind() == reflect.Struct {
-			fieldValue = fieldValue.FieldByName(col.fieldPath[i+1])
+			fieldValue = fieldValue.FieldByName(fieldPath[i+1])
 		} else if fieldValue.Kind() == reflect.Ptr {
 			if fieldValue.IsNil() {
 				fieldValue.Set(reflect.New(fieldValue.Type().Elem()))
 			}
-			fieldValue = fieldValue.Elem().FieldByName(col.fieldPath[i+1])
+			fieldValue = fieldValue.Elem().FieldByName(fieldPath[i+1])
 		} else {
 			return nil, fmt.Errorf("field  %v is not valid", col.FieldName)
 		}


### PR DESCRIPTION
xorm's core has potential data race [here](https://github.com/go-xorm/core/blob/master/column.go#L125)

For example, my test code(simplified) with parallel.

```golang
var db *xorm.Engine
func TestMain(m *testing.M) {
    db, _ = xorm.NewEngine("mysql", "...")
}

func TestA(t *testing.T) {
	t.Parallel()

	_, err := db.Where("name = ?", "A").Delete(Struct{})
	if err != nil {
		t.Error(err)
		t.FailNow()
	}
}

func TestB(t *testing.T) {
	t.Parallel()

	_, err := db.Where("name = ?", "B").Delete(Struct{})
	if err != nil {
		t.Error(err)
		t.FailNow()
	}
}
```

When I run `go test` with `-race` option, detect DATA RACE.

```
WARNING: DATA RACE
Read at 0x00c4201583e0 by goroutine 7:
  github.com/yonekawa/example/vendor/github.com/go-xorm/core.(*Column).ValueOfV()
      /Users/yonekawa/project/vendor/github.com/go-xorm/core/column.go:138 +0x250
  github.com/yonekawa/example/vendor/github.com/go-xorm/core.(*Column).ValueOf()
      /Users/yonekawa/project/vendor/github.com/go-xorm/core/column.go:119 +0xa1
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.buildConds()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/statement.go:518 +0x374
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.(*Statement).buildConds()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/statement.go:1104 +0x207
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.(*Statement).genConds()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/statement.go:1110 +0x20c
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.(*Session).Delete()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/session_delete.go:100 +0x314
  github.com/yonekawa/example/core/infra/database/a.TestB()
      /Users/yonekawa/project/core/infra/database/a/connection_test.go:23 +0x1f4
  testing.tRunner()
      /usr/local/Cellar/go/1.7.4_1/libexec/src/testing/testing.go:610 +0xc9

Previous write at 0x00c4201583e0 by goroutine 6:
  strings.genSplit()
      /usr/local/Cellar/go/1.7.4_1/libexec/src/strings/strings.go:259 +0x390
  strings.Split()
      /usr/local/Cellar/go/1.7.4_1/libexec/src/strings/strings.go:287 +0x72
  github.com/yonekawa/example/vendor/github.com/go-xorm/core.(*Column).ValueOfV()
      /Users/yonekawa/project/vendor/github.com/go-xorm/core/column.go:125 +0xe67
  github.com/yonekawa/example/vendor/github.com/go-xorm/core.(*Column).ValueOf()
      /Users/yonekawa/project/vendor/github.com/go-xorm/core/column.go:119 +0xa1
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.buildConds()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/statement.go:518 +0x374
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.(*Statement).buildConds()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/statement.go:1104 +0x207
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.(*Statement).genConds()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/statement.go:1110 +0x20c
  github.com/yonekawa/example/vendor/github.com/go-xorm/xorm.(*Session).Delete()
      /Users/yonekawa/project/vendor/github.com/go-xorm/xorm/session_delete.go:100 +0x314
  github.com/yonekawa/example/core/infra/database/a.TestA()
      /Users/yonekawa/project/core/infra/database/a/connection_test.go:13 +0x1f4
  testing.tRunner()
      /usr/local/Cellar/go/1.7.4_1/libexec/src/testing/testing.go:610 +0xc9
```

I think we don't need to cache fieldPath into Column.
Because, same logic is exists [here](https://github.com/go-xorm/xorm/blob/master/session.go#L408) without cache result.