### PR TITLE
fix: oracle default key in xorm tag error

### DIFF
--- a/column.go
+++ b/column.go
@@ -79,16 +79,16 @@ func (col *Column) String(d Dialect) string {
 		}
 	}
 
+	if col.Default != "" {
+		sql += "DEFAULT " + col.Default + " "
+	}
+
 	if d.ShowCreateNull() {
 		if col.Nullable {
 			sql += "NULL "
 		} else {
 			sql += "NOT NULL "
 		}
-	}
-
-	if col.Default != "" {
-		sql += "DEFAULT " + col.Default + " "
 	}
 
 	return sql
@@ -99,16 +99,16 @@ func (col *Column) StringNoPk(d Dialect) string {
 
 	sql += d.SqlType(col) + " "
 
+	if col.Default != "" {
+		sql += "DEFAULT " + col.Default + " "
+	}
+
 	if d.ShowCreateNull() {
 		if col.Nullable {
 			sql += "NULL "
 		} else {
 			sql += "NOT NULL "
 		}
-	}
-
-	if col.Default != "" {
-		sql += "DEFAULT " + col.Default + " "
 	}
 
 	return sql


### PR DESCRIPTION
fix: oracle default key in xorm tag error

Seems oracle (11g) not allow `DEFAULT` tag at last position.  
I test two sql for create table, the result is the following,  
![image](https://user-images.githubusercontent.com/3946563/31434736-ce98c83c-ae42-11e7-847d-3a0e0ab7c11a.png)


fix #29 