### PR TITLE
Add SetArguments(args) method for dialect_xxxxx.go support.

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -74,6 +74,7 @@ type Dialect interface {
 	GetIndexes(tableName string) (map[string]*Index, error)
 
 	Filters() []Filter
+	SetArguments(args map[string]string)
 }
 
 func OpenDialect(dialect Dialect) (*DB, error) {
@@ -287,6 +288,9 @@ func (b *Base) LogSQL(sql string, args []interface{}) {
 			b.logger.Infof("[SQL] %v", sql)
 		}
 	}
+}
+
+func (b *Base) SetArguments(args map[string]string) {
 }
 
 var (


### PR DESCRIPTION
ADD:
- The `SetArguments` method can pass any map[string]string object to dialect_xxxxx.go.

DETAILS:
- ref: https://github.com/go-xorm/xorm/issues/793
- xorm: https://github.com/go-xorm/xorm/pull/798