### PR TITLE
Add SYSNAME type for mssql sysdiagrams

### DIFF
--- a/type.go
+++ b/type.go
@@ -79,6 +79,7 @@ var (
 	LongText         = "LONGTEXT"
 	Uuid             = "UUID"
 	UniqueIdentifier = "UNIQUEIDENTIFIER"
+	SysName          = "SYSNAME"
 
 	Date       = "DATE"
 	DateTime   = "DATETIME"
@@ -133,6 +134,7 @@ var (
 		LongText:   TEXT_TYPE,
 		Uuid:       TEXT_TYPE,
 		Clob:       TEXT_TYPE,
+		SysName:    TEXT_TYPE,
 
 		Date:       TIME_TYPE,
 		DateTime:   TIME_TYPE,
@@ -291,7 +293,7 @@ func SQLType2Type(st SQLType) reflect.Type {
 		return reflect.TypeOf(float32(1))
 	case Double:
 		return reflect.TypeOf(float64(1))
-	case Char, Varchar, NVarchar, TinyText, Text, MediumText, LongText, Enum, Set, Uuid, Clob:
+	case Char, Varchar, NVarchar, TinyText, Text, MediumText, LongText, Enum, Set, Uuid, Clob, SysName:
 		return reflect.TypeOf("")
 	case TinyBlob, Blob, LongBlob, Bytea, Binary, MediumBlob, VarBinary, UniqueIdentifier:
 		return reflect.TypeOf([]byte{})


### PR DESCRIPTION
This fixes the bug:
`sync database struct error: Unknown colType SYSNAME for sysdiagrams - name
`
Reference:
https://github.com/go-xorm/xorm/issues/668
https://github.com/gogits/gogs/issues/4642