### PR TITLE
Rename args to params

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -74,7 +74,7 @@ type Dialect interface {
 	GetIndexes(tableName string) (map[string]*Index, error)
 
 	Filters() []Filter
-	SetArguments(args map[string]string)
+	SetParams(params map[string]string)
 }
 
 func OpenDialect(dialect Dialect) (*DB, error) {
@@ -290,7 +290,7 @@ func (b *Base) LogSQL(sql string, args []interface{}) {
 	}
 }
 
-func (b *Base) SetArguments(args map[string]string) {
+func (b *Base) SetParams(params map[string]string) {
 }
 
 var (


### PR DESCRIPTION
I prefer to use `params` but not `args`